### PR TITLE
Text Node Values

### DIFF
--- a/.d.ts
+++ b/.d.ts
@@ -1,2 +1,0 @@
-declare module 'remark-parse';
-declare module 'rehype-parse';

--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@ const defaults = {
   children(node) {
     return node.children;
   },
-  annotatetextnode(node) {
+  annotatetextnode(node, text) {
     if (node.type === "text") {
       return {
-        "text": node.value,
+        "text": text.substring(node.position.start.offset, node.position.end.offset),
         "offset": {
           "start": node.position.start.offset,
           "end": node.position.end.offset
@@ -22,11 +22,11 @@ const defaults = {
   }
 };
 
-function collecttextnodes(ast, options = defaults) {
+function collecttextnodes(ast, text, options = defaults) {
   var textannotations = [];
 
   function recurse(node) {
-    const annotation = options.annotatetextnode(node);
+    const annotation = options.annotatetextnode(node, text);
     if (annotation !== null) {
       textannotations.push(annotation);
     }
@@ -68,7 +68,7 @@ function composeannotation(text, annotatedtextnodes, options = defaults) {
 
 function build(text, parse, options = defaults) {
   const nodes = parse(text);
-  const textnodes = collecttextnodes(nodes, options);
+  const textnodes = collecttextnodes(nodes, text, options);
   return composeannotation(text, textnodes, options);
 }
 

--- a/test/escape-character.json
+++ b/test/escape-character.json
@@ -1,0 +1,192 @@
+{
+  "annotation": [
+    {
+      "markup": "# ",
+      "interpretAs": "",
+      "offset": {
+        "start": 0,
+        "end": 2
+      }
+    },
+    {
+      "text": "Backslash + Special Char = Shifted Highlight",
+      "offset": {
+        "start": 2,
+        "end": 46
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 46,
+        "end": 48
+      }
+    },
+    {
+      "text": "This is a inccoreect sentence.",
+      "offset": {
+        "start": 48,
+        "end": 78
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 78,
+        "end": 80
+      }
+    },
+    {
+      "text": "Here is the culprit: ",
+      "offset": {
+        "start": 80,
+        "end": 101
+      }
+    },
+    {
+      "markup": "",
+      "interpretAs": "",
+      "offset": {
+        "start": 101,
+        "end": 101
+      }
+    },
+    {
+      "text": "\\-",
+      "offset": {
+        "start": 101,
+        "end": 103
+      }
+    },
+    {
+      "markup": "",
+      "interpretAs": "",
+      "offset": {
+        "start": 103,
+        "end": 103
+      }
+    },
+    {
+      "text": ".",
+      "offset": {
+        "start": 103,
+        "end": 104
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 104,
+        "end": 106
+      }
+    },
+    {
+      "text": "This is annother incorrect sentence.",
+      "offset": {
+        "start": 106,
+        "end": 142
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 142,
+        "end": 144
+      }
+    },
+    {
+      "text": "Here is another culprit: ",
+      "offset": {
+        "start": 144,
+        "end": 169
+      }
+    },
+    {
+      "markup": "",
+      "interpretAs": "",
+      "offset": {
+        "start": 169,
+        "end": 169
+      }
+    },
+    {
+      "text": "\\;",
+      "offset": {
+        "start": 169,
+        "end": 171
+      }
+    },
+    {
+      "markup": "",
+      "interpretAs": "",
+      "offset": {
+        "start": 171,
+        "end": 171
+      }
+    },
+    {
+      "text": ".",
+      "offset": {
+        "start": 171,
+        "end": 172
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 172,
+        "end": 174
+      }
+    },
+    {
+      "text": "This is annother incorrect sentence.",
+      "offset": {
+        "start": 174,
+        "end": 210
+      }
+    },
+    {
+      "markup": "\n\n* ",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 210,
+        "end": 214
+      }
+    },
+    {
+      "text": "Is this yet another?",
+      "offset": {
+        "start": 214,
+        "end": 234
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 234,
+        "end": 236
+      }
+    },
+    {
+      "text": "This is annother incorrect sentence.",
+      "offset": {
+        "start": 236,
+        "end": 272
+      }
+    },
+    {
+      "markup": "\n",
+      "interpretAs": "\n",
+      "offset": {
+        "start": 272,
+        "end": 273
+      }
+    }
+  ]
+}

--- a/test/escape-character.md
+++ b/test/escape-character.md
@@ -1,0 +1,15 @@
+# Backslash + Special Char = Shifted Highlight
+
+This is a inccoreect sentence.
+
+Here is the culprit: \-.
+
+This is annother incorrect sentence.
+
+Here is another culprit: \;.
+
+This is annother incorrect sentence.
+
+* Is this yet another?
+
+This is annother incorrect sentence.

--- a/test/test.js
+++ b/test/test.js
@@ -15,9 +15,10 @@ options.interpretmarkup = function (text) {
 describe("#collecttextnodes()", function () {
 
   it("should return the expected array of text nodes", function () {
+    const text = fs.readFileSync("./test/test.md", "utf8");
     const ast = JSON.parse(fs.readFileSync("./test/ast.json", "utf8"));
     const expected = JSON.parse(fs.readFileSync("./test/textnodes.json", "utf8"));
-    const result = builder.collecttextnodes(ast, options);
+    const result = builder.collecttextnodes(ast, text, options);
     expect(result).to.deep.equal(expected);
   });
 
@@ -48,6 +49,29 @@ describe("#build()", function () {
 
   it("should match the original document exactly", function () {
     const expected = fs.readFileSync("./test/test.md", "utf8");
+    const processor = unified()
+      .use(remarkparse, { commonmark: true });
+    const annotatedtext = builder.build(expected, processor.parse, options);
+    const annotation = annotatedtext.annotation;
+    let result = "";
+    for (let node of annotation) {
+      const text = node.text ? node.text : node.markup;
+      result += text;
+    }
+    expect(result).to.equal(expected);
+  });
+
+  it("should return the expected annotated text with backslashes object", function () {
+    const expected = JSON.parse(fs.readFileSync("./test/escape-character.json", "utf8"));
+    const text = fs.readFileSync("./test/escape-character.md", "utf8");
+    const processor = unified()
+      .use(remarkparse, { commonmark: true });
+    const result = builder.build(text, processor.parse, options);
+    expect(result).to.deep.equal(expected);
+  });
+
+  it("should match the original document with backslashes exactly", function () {
+    const expected = fs.readFileSync("./test/escape-character.md", "utf8");
     const processor = unified()
       .use(remarkparse, { commonmark: true });
     const annotatedtext = builder.build(expected, processor.parse, options);


### PR DESCRIPTION
`text` nodes now pull their value directly from the source text instead of relying on the parser for their value. `markup` nodes already pulled their values from the original text.