### PR TITLE
ci: added dependabot dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,21 @@ updates:
       include: scope
     reviewers:
       - davidlday
+    groups:
+      dev-typescript-eslint:
+        dependency-type: "development"
+        patterns:
+          - "@typescript-eslint/*"
+      dev-mocha:
+        dependency-type: "development"
+        patterns:
+          - "mocha"
+          - "@types/mocha"
+      dev-chai:
+        dependency-type: "development"
+        patterns:
+          - "chai"
+          - "@types/chai"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Added [dependency groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) for dependabot.